### PR TITLE
[update] : 새로운 주소록 기능 업데이트

### DIFF
--- a/src/main/java/com/precapstone/fiveguys_backend/api/contact2/Contact2Repository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/contact2/Contact2Repository.java
@@ -1,9 +1,13 @@
 package com.precapstone.fiveguys_backend.api.contact2;
 
 import com.precapstone.fiveguys_backend.entity.Contact2;
+import com.precapstone.fiveguys_backend.entity.Group2;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface Contact2Repository extends JpaRepository<Contact2, Long> {
+    @Transactional
+    void deleteAllByGroup2(Group2 group2);
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/contact2/Contact2Service.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/contact2/Contact2Service.java
@@ -73,11 +73,24 @@ public class Contact2Service {
         if(!contact2.getGroup2().getFolder2().getUser().getUserId().equals(userId))
             throw new ControlledException(USER_AUTHORIZATION_FAILED);
 
-        if(contact2UpdateDTO.getName() != null)
+        if(contact2UpdateDTO.getName() != null) {
+            // 1. [예외처리] 본인 Group2 안에 Contact2가 이미 존재하는 경우
+            var contact2s = contact2.getGroup2().getContact2s();
+            for(var contact : contact2s)
+                if (contact.getName().equals(contact2UpdateDTO.getName()))
+                    throw new ControlledException(CONTACT2_NAME_ALREADY_EXISTS_IN_THIS_GROUP2);
             contact2.setName(contact2UpdateDTO.getName());
+        }
 
-        if(contact2UpdateDTO.getTelNum() != null)
+        if(contact2UpdateDTO.getTelNum() != null) {
+            // 1. [예외처리] 본인 Group2 안에 Contact2가 이미 존재하는 경우
+            var contact2s = contact2.getGroup2().getContact2s();
+            for(var contact : contact2s)
+                if (contact.getTelNum().equals(contact2UpdateDTO.getTelNum()))
+                    throw new ControlledException(CONTACT2_TELNUM_ALREADY_EXISTS_IN_THIS_GROUP2);
+
             contact2.setTelNum(contact2UpdateDTO.getTelNum());
+        }
 
         if(contact2UpdateDTO.getOne() != null) contact2.setOne(contact2UpdateDTO.getOne());
         if(contact2UpdateDTO.getTwo() != null) contact2.setTwo(contact2UpdateDTO.getTwo());

--- a/src/main/java/com/precapstone/fiveguys_backend/api/folder2/Folder2CreateDTO.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/folder2/Folder2CreateDTO.java
@@ -6,6 +6,5 @@ import lombok.Getter;
 @Builder
 @Getter
 public class Folder2CreateDTO {
-    private Long userId;
     private String name;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/folder2/Folder2Repository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/folder2/Folder2Repository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface Folder2Repository extends JpaRepository<Folder2, Long> {
-    Optional<Folder2> findByName(String name);
+    Optional<Folder2> findByUserAndName(User user, String name);
     Optional<List<Folder2>> findByUser(User user);
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Controller.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Controller.java
@@ -1,16 +1,21 @@
 package com.precapstone.fiveguys_backend.api.group2;
 
+import com.precapstone.fiveguys_backend.api.contact2.Contact2Service;
 import com.precapstone.fiveguys_backend.common.CommonResponse;
 import com.precapstone.fiveguys_backend.common.auth.JwtFilter;
+import com.precapstone.fiveguys_backend.entity.Contact2;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/group2/")
 @RequiredArgsConstructor
 public class Group2Controller {
     private final Group2Service group2Service;
+    private final Contact2Service contact2Service;
 
     // 그룹2 생성
     @PostMapping
@@ -42,6 +47,17 @@ public class Group2Controller {
         var group2 = group2Service.update(group2UpdateDTO, accessToken);
 
         var response = CommonResponse.builder().code(200).message("그룹2 수정 성공").data(group2).build();
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{group2Id}")
+    public ResponseEntity updateContact2s(@PathVariable Long group2Id, @RequestBody List<Contact2> contact2s, @RequestHeader("Authorization") String authorization) {
+        var accessToken = authorization.replace(JwtFilter.TOKEN_PREFIX, "");
+
+        contact2Service.deleteAllByGroup2Id(group2Id, accessToken);
+        var group2 = group2Service.updateContact2s(group2Id, contact2s, accessToken);
+
+        var response = CommonResponse.builder().code(200).message("그룹2 Contact2s 수정 성공").data(group2).build();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Service.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Service.java
@@ -2,10 +2,13 @@ package com.precapstone.fiveguys_backend.api.group2;
 
 import com.precapstone.fiveguys_backend.api.auth.JwtTokenProvider;
 import com.precapstone.fiveguys_backend.api.folder2.Folder2Service;
+import com.precapstone.fiveguys_backend.entity.Contact2;
 import com.precapstone.fiveguys_backend.entity.Group2;
 import com.precapstone.fiveguys_backend.exception.ControlledException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static com.precapstone.fiveguys_backend.exception.errorcode.Group2ErrorCode.*;
 import static com.precapstone.fiveguys_backend.exception.errorcode.UserErrorCode.USER_AUTHORIZATION_FAILED;
@@ -73,6 +76,21 @@ public class Group2Service {
                 throw new ControlledException(INVALID_FORMAT_BY_FOLDER2_ID);
             }
         }
+
+        group2Repository.save(group2);
+        return group2;
+    }
+
+    public Group2 updateContact2s(Long group2Id, List<Contact2> contact2s, String accessToken) {
+        var group2 = readGroup2(group2Id, accessToken);
+
+        // [보안] 데이터의 주인이 호출한 API인지 accessToken을 통해 확인
+        // ※ 이미 readGroup2()에서 인증을 거치지만 형식상 추가
+        var userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+        if(!group2.getFolder2().getUser().getUserId().equals(userId))
+            throw new ControlledException(USER_AUTHORIZATION_FAILED);
+
+        group2.setContact2s(contact2s);
 
         group2Repository.save(group2);
         return group2;

--- a/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Service.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/group2/Group2Service.java
@@ -64,8 +64,14 @@ public class Group2Service {
         if(!group2.getFolder2().getUser().getUserId().equals(userId))
             throw new ControlledException(USER_AUTHORIZATION_FAILED);
 
-        if(group2UpdateDTO.getName() != null)
+        if(group2UpdateDTO.getName() != null) {
+            // 1. [예외처리] 본인 Folder2 안에 Group2가 이미 존재하는 경우
+            var groups = group2.getFolder2().getGroup2s();
+            for(var group : groups)
+                if(group.getName().equals(group2UpdateDTO.getName()))
+                    throw new ControlledException(GROUP2_NAME_ALREADY_EXISTS_IN_THIS_FOLDER2);
             group2.setName(group2UpdateDTO.getName());
+        }
 
         if(group2UpdateDTO.getFolder2Id() != null) {
             try {

--- a/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/Contact2ErrorCode.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/Contact2ErrorCode.java
@@ -5,4 +5,5 @@ import com.precapstone.fiveguys_backend.exception.ErrorMessage;
 public interface Contact2ErrorCode {
     ErrorMessage CONTACT2_NOT_FOUND = new ErrorMessage(-5001, "조회된 주소록2가 없습니다.");
     ErrorMessage CONTACT2_NAME_ALREADY_EXISTS_IN_THIS_GROUP2 = new ErrorMessage(-5002, "이미 해당 그룹 내부에 동일한 이름의 주소록이 있습니다.");
+    ErrorMessage CONTACT2_TELNUM_ALREADY_EXISTS_IN_THIS_GROUP2 = new ErrorMessage(-5002, "이미 해당 그룹 내부에 동일한 전화번호의 주소록이 있습니다.");
 }


### PR DESCRIPTION
# :: 작업 주제
*FG-11* : fiveguys-frontend에서 필요한 연락처 관련 API 추가

# :: 구현사항 설명
1. Folder2CreateDTO에 존재하던 userId 변수 삭제   
    - 이미 authorization에서 유저 아이디를 조회할 수 있기 때문  
2. Group2 내부에 있는 contact2s를 전체 덮어쓰기 가능하도록 변경. 
    - excel에서는 수정 사항이 아닌 모든 내용을 동시에 저장하기 때문
3. 예외 로직 수정
    - 기존 예외처리 로직 확인 결과 일부 Service에서 전체 테이블에서 명칭 중복검사를 하는 것으로 확인되어 수정
    - Folder 중복 검사 시, 이름 중복만 확인하였는데, 전화번호까지 중복 검사 하도록 변경

# :: 보완할점
<보완사항, 주의사항>
1. 로컬에서만 테스트 완료된 상황이므로, 배포 후 추가적인 테스트 필요

<추가로 알아야할 사항>