### PR TITLE
[feat] : 메세지 사용량 조회 서비스 수정

### DIFF
--- a/src/main/java/com/precapstone/fiveguys_backend/api/amountused/AmountUsedController.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/amountused/AmountUsedController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/amountController/")
@@ -13,13 +15,24 @@ public class AmountUsedController {
     private final AmountUsedService amountUsedService;
 
     // 사용량 조회
-    @GetMapping("/{amountUsedId}")
+    @GetMapping
     public ResponseEntity read(@RequestHeader("Authorization") String authorization) {
         var accessToken = authorization.replace(JwtFilter.TOKEN_PREFIX, "");
 
         var amountUsed = amountUsedService.read(accessToken);
 
         var response = CommonResponse.builder().code(200).message("사용량 조회 성공").data(amountUsed).build();
+        return ResponseEntity.ok(response);
+    }
+
+    // 일일 사용량 조회
+    @GetMapping("day/{localDate}")
+    public ResponseEntity readByDay(@RequestHeader("Authorization") String authorization, @PathVariable LocalDate localDate) {
+        var accessToken = authorization.replace(JwtFilter.TOKEN_PREFIX, "");
+
+        var dailyAmount = amountUsedService.readByDay(accessToken, localDate);
+
+        var response = CommonResponse.builder().code(200).message("일일 사용량 조회 성공").data(dailyAmount).build();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/amountused/AmountUsedService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/amountused/AmountUsedService.java
@@ -1,14 +1,17 @@
 package com.precapstone.fiveguys_backend.api.amountused;
 
 import com.precapstone.fiveguys_backend.api.auth.JwtTokenProvider;
+import com.precapstone.fiveguys_backend.api.dailyamount.DailyAmountService;
 import com.precapstone.fiveguys_backend.api.user.UserService;
 import com.precapstone.fiveguys_backend.entity.AmountUsed;
+import com.precapstone.fiveguys_backend.entity.DailyAmount;
 import com.precapstone.fiveguys_backend.entity.User;
 import com.precapstone.fiveguys_backend.exception.ControlledException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -23,7 +26,7 @@ public class AmountUsedService {
     public final AmountUsedRepository amountUsedRepository;
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
-    // private final DailyThread dailyThread = new DailyThread();
+    private final DailyAmountService dailyAmountService;
 
     public AmountUsed create(User user) {
         var amountUsed = AmountUsed.builder()
@@ -57,6 +60,16 @@ public class AmountUsedService {
         return amountUsed;
     }
 
+    public DailyAmount readByDay(String accessToken, LocalDate localDate) {
+        var userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+        var amountUsed = userService.findByUserId(userId)
+                .orElseThrow(() -> new ControlledException(USER_NOT_FOUND))
+                .getAmountUsed();
+
+        var dailyAmount = dailyAmountService.read(amountUsed, localDate);
+        return dailyAmount;
+    }
+
     /**
      * 메세지 사용량 카운트를 증가시키는 함수
      *
@@ -66,19 +79,22 @@ public class AmountUsedService {
                 .orElseThrow(()->new ControlledException(USER_NOT_FOUND)).getAmountUsed();
 
         switch (amountUsedType) {
-            case MSG_SCNT: // 문자 전송 카운트
+            case MSG_SCNT: // 문자 전송 카운트 (문자를 전송한 인원수)
                 amountUsed.setMsgScnt(amountUsed.getMsgScnt()+plus);
+                dailyAmountService.plus(amountUsed, amountUsedType, plus);
                 break;
-            case MSG_GCNT: // 문자 생성 카운트 // TODO: 이거 기준이 모호
+            case MSG_GCNT: // 문자 생성 카운트 (문자 전송 횟수)
                 amountUsed.setMsgGcnt(amountUsed.getMsgGcnt()+plus);
+                dailyAmountService.plus(amountUsed, amountUsedType, plus);
                 break;
-            case IMG_SCNT: // 이미지 전송 카운트
+            case IMG_SCNT: // 이미지 전송 카운트 (이미지를 전송한 인원수)
                 amountUsed.setImgScnt(amountUsed.getImgScnt()+plus);
+                dailyAmountService.plus(amountUsed, amountUsedType, plus);
                 break;
-            case IMG_GCNT: // 이미지 생성 카운트
+            case IMG_GCNT: // 이미지 생성 카운트 (이미지 전송 횟수)
                 amountUsed.setImgGcnt(amountUsed.getImgGcnt()+plus);
-                amountUsed.setImgDcnt(amountUsed.getImgDcnt()+plus);
-                amountUsed.setImgDate(LocalDateTime.now());
+                amountUsed.setLastDate(LocalDateTime.now());
+                dailyAmountService.plus(amountUsed, amountUsedType, plus);
                 break;
             default:
                 throw new ControlledException(AMOUNT_USED_NOT_FOUND);
@@ -88,56 +104,10 @@ public class AmountUsedService {
         return amountUsed;
     }
 
-    /**
-     * 일간 이용자 카운트 초기화
-     *
-     */
-    public List<AmountUsed> initDcnt() {
-        var allAmountUsed = amountUsedRepository.findAll();
-
-        allAmountUsed.forEach(amountUsed -> {amountUsed.setImgDcnt(0);});
-
-        return allAmountUsed;
-    }
-
     public AmountUsed delete(Long amountUsedId) {
         var amountUsed = read(amountUsedId);
 
         amountUsedRepository.deleteById(amountUsedId);
         return amountUsed;
     }
-
-    private class DailyThread implements Runnable {
-        @Override
-        public void run() {
-            while (true) {
-                try {
-                    log.info("진입!!");
-                    // 현재 시간 가져오기
-                    long currentTimeMillis = System.currentTimeMillis();
-                    java.util.Calendar calendar = java.util.Calendar.getInstance();
-                    calendar.setTimeInMillis(currentTimeMillis);
-
-                    // 다음 00시 00분까지의 대기 시간 계산
-                    calendar.add(java.util.Calendar.DAY_OF_MONTH, 1); // 다음 날로 설정
-                    calendar.set(java.util.Calendar.HOUR_OF_DAY, 0);
-                    calendar.set(java.util.Calendar.MINUTE, 0);
-                    calendar.set(java.util.Calendar.SECOND, 0);
-                    calendar.set(java.util.Calendar.MILLISECOND, 0);
-
-                    long nextMidnightMillis = calendar.getTimeInMillis();
-                    long sleepTime = nextMidnightMillis - currentTimeMillis;
-
-                    // 다음 00시 00분까지 대기
-                    Thread.sleep(sleepTime);
-
-                    // 00시 00분이 지나면 initDcnt() 호출
-                    initDcnt();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-    }
-
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/dailyamount/DailyAmountRepository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/dailyamount/DailyAmountRepository.java
@@ -1,0 +1,17 @@
+package com.precapstone.fiveguys_backend.api.dailyamount;
+
+import com.precapstone.fiveguys_backend.entity.AmountUsed;
+import com.precapstone.fiveguys_backend.entity.DailyAmount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface DailyAmountRepository extends JpaRepository<DailyAmount, Long> {
+    Optional<DailyAmount> findByAmountUsedAndDate(AmountUsed amountUsed, LocalDate date);
+    Optional<DailyAmount> findByDailyAmountId(Long dailyAmountId);
+    void deleteByDailyAmountId(Long dailyAmountId);
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/dailyamount/DailyAmountService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/dailyamount/DailyAmountService.java
@@ -1,0 +1,49 @@
+package com.precapstone.fiveguys_backend.api.dailyamount;
+
+import com.precapstone.fiveguys_backend.api.amountused.AmountUsedType;
+import com.precapstone.fiveguys_backend.entity.AmountUsed;
+import com.precapstone.fiveguys_backend.entity.DailyAmount;
+import com.precapstone.fiveguys_backend.exception.ControlledException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+import static com.precapstone.fiveguys_backend.exception.errorcode.AmountUsedErrorCode.AMOUNT_USED_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class DailyAmountService {
+    private final DailyAmountRepository dailyAmountRepository;
+
+    public DailyAmount read(AmountUsed amountUsed, LocalDate localDate) {
+        var dailyAmount = dailyAmountRepository.findByAmountUsedAndDate(amountUsed, localDate)
+                .orElseGet(() -> dailyAmountRepository.save(DailyAmount.builder().amountUsed(amountUsed).date(localDate).build()));
+
+        return dailyAmount;
+    }
+
+    public DailyAmount plus(AmountUsed amountUsed, AmountUsedType amountUsedType, Integer plus) {
+        var dailyAmount = read(amountUsed, LocalDate.now());
+
+        switch (amountUsedType) {
+            case MSG_SCNT: // 문자 전송 카운트 (문자를 전송한 인원수)
+                dailyAmount.setMsgScnt(dailyAmount.getMsgScnt()+plus);
+                break;
+            case MSG_GCNT: // 문자 생성 카운트 (문자 전송 횟수)
+                dailyAmount.setMsgGcnt(dailyAmount.getMsgGcnt()+plus);
+                break;
+            case IMG_SCNT: // 이미지 전송 카운트 (이미지를 전송한 인원수)
+                dailyAmount.setImgScnt(dailyAmount.getImgScnt()+plus);
+                break;
+            case IMG_GCNT: // 이미지 생성 카운트 (이미지 전송 횟수)
+                dailyAmount.setImgGcnt(dailyAmount.getImgGcnt()+plus);
+                break;
+            default:
+                throw new ControlledException(AMOUNT_USED_NOT_FOUND);
+        }
+
+        dailyAmountRepository.save(dailyAmount);
+        return dailyAmount;
+    }
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/image/ImageService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/image/ImageService.java
@@ -101,7 +101,6 @@ public class ImageService {
 
         try {
             this.saveImageResultIntoDB(result, userId);
-            amountUsedService.plus(userId, AmountUsedType.IMG_GCNT, 1);
             return CommonResponse.builder()
                     .code(200)
                     .data(ImageResponseDTO.builder()
@@ -169,7 +168,6 @@ public class ImageService {
 
         try {
             this.saveImageResultIntoDB(result, userId);
-            amountUsedService.plus(userId, AmountUsedType.IMG_GCNT, 1);
             return CommonResponse.builder()
                     .code(200)
                     .data(ImageResponseDTO.builder()

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioSendService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioSendService.java
@@ -62,8 +62,14 @@ public class PpurioSendService {
 
         // 사용량 증가
         var userId = jwtTokenProvider.getUserIdFromToken(fiveguysAccessToken);
-        if(ppurioMessageDTO.getMessageType().equals("MMS")) amountUsedService.plus(userId, AmountUsedType.IMG_SCNT, 1);
-        else amountUsedService.plus(userId, AmountUsedType.MSG_SCNT, 1);
+        if(ppurioMessageDTO.getMessageType().equals("MMS")) {
+            amountUsedService.plus(userId, AmountUsedType.IMG_SCNT, 1);
+            amountUsedService.plus(userId, AmountUsedType.IMG_GCNT, ppurioMessageDTO.getTargets().size());
+        }
+        else {
+            amountUsedService.plus(userId, AmountUsedType.MSG_SCNT, 1);
+            amountUsedService.plus(userId, AmountUsedType.MSG_GCNT, ppurioMessageDTO.getTargets().size());
+        }
         
         // 전송
         var messageHistoryDTO = getMessageHistoryDTO(userId, multipartFile, ppurioMessageDTO);
@@ -86,7 +92,9 @@ public class PpurioSendService {
             var requestBody = createMessageParams(ppurioMessageDTO, null);
             HttpEntity<Map> request = new HttpEntity<>(requestBody, headers);
             var userId = jwtTokenProvider.getUserIdFromToken(fiveguysAccessToken);
+
             amountUsedService.plus(userId, AmountUsedType.MSG_SCNT, 1);
+            amountUsedService.plus(userId, AmountUsedType.MSG_GCNT, ppurioMessageDTO.getTargets().size());
 
             var messageHistoryDTO = getMessageHistoryDTO(userId, null, ppurioMessageDTO);
             messageHistoryService.createLink(messageHistoryDTO, bucketURL);
@@ -170,7 +178,7 @@ public class PpurioSendService {
                 .content(ppurioMessageDTO.getContent())
                 .fromNumber(ppurioMessageDTO.getFromNumber())
                 // MessageType 중복 사용
-                .messageType(com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageType.valueOf(ppurioMessageDTO.getMessageType()))
+                .messageType(com.precapstone.fiveguys_backend.entity.messagehistory.MessageType.valueOf(ppurioMessageDTO.getMessageType()))
                 .subject(ppurioMessageDTO.getSubject())
                 .contact2s(getContact2s(ppurioMessageDTO.getTargets())) // TODO: target으로 반환하는 문제 발생
                 .sendImage(multipartFile)

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryDTO.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryDTO.java
@@ -1,6 +1,6 @@
 package com.precapstone.fiveguys_backend.api.messagehistory;
 
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageType;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageType;
 import com.precapstone.fiveguys_backend.entity.Contact2;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryRepository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.precapstone.fiveguys_backend.api.messagehistory;
 
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageHistory;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
 import com.precapstone.fiveguys_backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
@@ -1,9 +1,9 @@
 package com.precapstone.fiveguys_backend.api.messagehistory;
 
 import com.precapstone.fiveguys_backend.api.auth.JwtTokenProvider;
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageHistory;
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageType;
-import com.precapstone.fiveguys_backend.api.sendimage.SendImage;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageType;
+import com.precapstone.fiveguys_backend.entity.SendImage;
 import com.precapstone.fiveguys_backend.api.sendimage.SendImageService;
 import com.precapstone.fiveguys_backend.api.user.UserService;
 import com.precapstone.fiveguys_backend.exception.ControlledException;

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/messagehistory/MessageType.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/messagehistory/MessageType.java
@@ -1,7 +1,0 @@
-package com.precapstone.fiveguys_backend.api.messagehistory.messagehistory;
-
-public enum MessageType {
-    SMS,
-    LMS,
-    MMS
-}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/sendimage/SendImageRepository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/sendimage/SendImageRepository.java
@@ -1,5 +1,6 @@
 package com.precapstone.fiveguys_backend.api.sendimage;
 
+import com.precapstone.fiveguys_backend.entity.SendImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/precapstone/fiveguys_backend/api/sendimage/SendImageService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/sendimage/SendImageService.java
@@ -1,7 +1,8 @@
 package com.precapstone.fiveguys_backend.api.sendimage;
 
 import com.precapstone.fiveguys_backend.api.aws.AwsS3Service;
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageHistory;
+import com.precapstone.fiveguys_backend.entity.SendImage;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
 import com.precapstone.fiveguys_backend.exception.ControlledException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/DailyAmount.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/DailyAmount.java
@@ -1,12 +1,10 @@
 package com.precapstone.fiveguys_backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -14,16 +12,11 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "amount_used")
-public class AmountUsed {
+@Table(name = "daily_amount")
+public class DailyAmount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long amountUsedId;
-
-    // 유저 정보
-    @JsonBackReference
-    @OneToOne(mappedBy = "amountUsed")
-    private User user;
+    private Long dailyAmountId;
 
     // 문자 발신 총 횟수
     @Builder.Default
@@ -33,23 +26,21 @@ public class AmountUsed {
     @Builder.Default
     @Column(nullable = false)
     private Integer msgGcnt = 0;
-    
-    // 이미지 발신 총 횟수
+
     @Builder.Default
     @Column(nullable = false)
     private Integer imgScnt = 0;
-    
-    // 이미지 생성 총 횟수
+
     @Builder.Default
     @Column(nullable = false)
     private Integer imgGcnt = 0;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JsonManagedReference
-    private List<DailyAmount> dailyAmounts;
-
-    // 마지막 이미지 생성 일자
     @Builder.Default
     @Column(nullable = false)
-    private LocalDateTime lastDate = LocalDateTime.now();
+    private LocalDate date = LocalDate.now();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "amount_used_id")
+    @JsonBackReference
+    private AmountUsed amountUsed;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/SendImage.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/SendImage.java
@@ -1,7 +1,7 @@
-package com.precapstone.fiveguys_backend.api.sendimage;
+package com.precapstone.fiveguys_backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.precapstone.fiveguys_backend.api.messagehistory.messagehistory.MessageHistory;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/User.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/User.java
@@ -32,7 +32,7 @@ public class User {
     private LocalDateTime updatedAt;
 
     @Setter
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "amount_used_id")
     @JsonManagedReference
     private AmountUsed amountUsed;

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
@@ -1,8 +1,8 @@
-package com.precapstone.fiveguys_backend.api.messagehistory.messagehistory;
+package com.precapstone.fiveguys_backend.entity.messagehistory;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.precapstone.fiveguys_backend.api.sendimage.SendImage;
+import com.precapstone.fiveguys_backend.entity.SendImage;
 import com.precapstone.fiveguys_backend.entity.Contact2;
 import com.precapstone.fiveguys_backend.entity.User;
 import jakarta.persistence.*;
@@ -51,6 +51,6 @@ public class MessageHistory {
     
     @JsonManagedReference
     @JoinColumn(name = "send_image_id")
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     private SendImage sendImage;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageType.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageType.java
@@ -1,0 +1,7 @@
+package com.precapstone.fiveguys_backend.entity.messagehistory;
+
+public enum MessageType {
+    SMS,
+    LMS,
+    MMS
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/DailyAmountErrorCode.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/DailyAmountErrorCode.java
@@ -1,0 +1,8 @@
+package com.precapstone.fiveguys_backend.exception.errorcode;
+
+import com.precapstone.fiveguys_backend.exception.ErrorMessage;
+
+public interface DailyAmountErrorCode {
+    ErrorMessage DAILY_AMOUNT_NOT_FOUND = new ErrorMessage(-7001, "조회된 일일 사용량이 없습니다.");
+    ErrorMessage DAILY_AMOUNT_NOT_FOUND_TODAY = new ErrorMessage(-7002, "당일 조회된 일일 사용량이 없습니다.");
+}


### PR DESCRIPTION
# :: 작업 주제
*FG-12* : 문자 기록 기능 구현

# :: 구현사항 설명
1. 문자 사용량 조회 기능 수정
2. 전체 사용량과 일일 사용량 엔티티로 분리
3. 일일 조회의 경우 매일 기록이 DB에 저장됨.

# :: 보완할점
<보완사항, 주의사항>
- [ ] 실제 전송 후 기록을 보기위해 메인 서버에서 테스트 필요

<추가로 알아야할 사항>
