### PR TITLE
[FG-49] 이미지 예약 전송 기능 추가

### DIFF
--- a/src/main/java/com/precapstone/fiveguys_backend/api/dto/PpurioSendDTO.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/dto/PpurioSendDTO.java
@@ -4,6 +4,7 @@ import com.precapstone.fiveguys_backend.api.message.send.option.Target;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -19,5 +20,5 @@ public class PpurioSendDTO {
     List<Target> targets;
     String subject;
     List<String> filePaths;
-    //TODO: 예약 시간 설정
+    LocalDateTime sendTime;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/PpurioMessageDTO.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/PpurioMessageDTO.java
@@ -1,12 +1,11 @@
 package com.precapstone.fiveguys_backend.api.message;
 
-import com.precapstone.fiveguys_backend.api.message.send.option.Files;
 import com.precapstone.fiveguys_backend.api.message.send.option.Target;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -18,4 +17,5 @@ public class PpurioMessageDTO {
     String fromNumber;
     List<Target> targets;
     String subject;
+    LocalDateTime sendTime;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/PpurioSendController.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/PpurioSendController.java
@@ -57,4 +57,11 @@ public class PpurioSendController {
         return CommonResponse.builder().code(200).message("문자 전송 성공").data(response).build();
     }
 
+    @PostMapping(value = "cancel/{messageHistoryId}")
+    public CommonResponse cancel(@PathVariable Long messageHistoryId, @RequestHeader("Authorization") String authorization) {
+        var accessToken = authorization.replace(JwtFilter.TOKEN_PREFIX, "");
+
+        var response = ppurioSendService.cancel(messageHistoryId, accessToken);
+        return CommonResponse.builder().code(200).message("예약 문자 취소 성공").data(response).build();
+    }
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioCancelResponse.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioCancelResponse.java
@@ -1,0 +1,13 @@
+package com.precapstone.fiveguys_backend.api.message.send;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+public class PpurioCancelResponse {
+    private String code;
+    private String description;
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioSendService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/PpurioSendService.java
@@ -72,9 +72,12 @@ public class PpurioSendService {
         }
         
         // 전송
+        var ppurioSendResponse = restTemplate.postForObject(url+"/v1/message", request, PpurioSendResponse.class);
+
+        // 메세지 저장
         var messageHistoryDTO = getMessageHistoryDTO(userId, multipartFile, ppurioMessageDTO);
-        messageHistoryService.create(messageHistoryDTO);
-        return restTemplate.postForObject(url+"/v1/message", request, PpurioSendResponse.class);
+        messageHistoryService.create(messageHistoryDTO, ppurioSendResponse.getMessageKey());
+        return ppurioSendResponse;
     }
 
     public PpurioSendResponse messageLink(PpurioMessageDTO ppurioMessageDTO, MultipartFile multipartFile, String fiveguysAccessToken) {
@@ -96,9 +99,11 @@ public class PpurioSendService {
             amountUsedService.plus(userId, AmountUsedType.MSG_GCNT, 1);
             amountUsedService.plus(userId, AmountUsedType.MSG_SCNT, ppurioMessageDTO.getTargets().size());
 
+            var ppurioSendResponse = restTemplate.postForObject(url+"/v1/message", request, PpurioSendResponse.class);
+
             var messageHistoryDTO = getMessageHistoryDTO(userId, null, ppurioMessageDTO);
-            messageHistoryService.createLink(messageHistoryDTO, bucketURL);
-            return restTemplate.postForObject(url+"/v1/message", request, PpurioSendResponse.class);
+            messageHistoryService.createLink(messageHistoryDTO, bucketURL, ppurioSendResponse.getMessageKey());
+            return ppurioSendResponse;
         } catch (Exception e){
             return null;
         }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/LMS.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/LMS.java
@@ -20,7 +20,7 @@ public class LMS extends MessageType {
      * MessageType와 동일한 방식으로 진행된다.
      */
     public LMS(String ppurioAccount, String fromNumber, String message, List<Target> targets) {
-        super(ppurioAccount, fromNumber, message, targets);
+        super(ppurioAccount, fromNumber, message, targets, null);
 
         // TODO: 문자 메세지 길이 파악하기(더 길 시 에러메세지 발송)
 
@@ -28,7 +28,7 @@ public class LMS extends MessageType {
     }
 
     public LMS(String ppurioAccount, PpurioMessageDTO ppurioMessageDTO) {
-        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets());
+        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets(), ppurioMessageDTO.getSendTime());
 
         // 문자 메세지 길이 파악하기(더 길 시 에러메세지 발송)
         if(ppurioMessageDTO.getContent().getBytes().length > 2000) throw new ControlledException(CONTENT_IS_TOO_LONG);

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/MMS.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/MMS.java
@@ -26,7 +26,7 @@ public class MMS extends MessageType {
      * @throws IOException
      */
     public MMS(String ppurioAccount, String fromNumber, String message, List<Target> targets, List<String> filePaths) throws IOException {
-        super(ppurioAccount, fromNumber, message, targets);
+        super(ppurioAccount, fromNumber, message, targets, null);
 
         params.put("messageType", "MMS");
         params.put("files", List.of(
@@ -35,7 +35,7 @@ public class MMS extends MessageType {
     }
 
     public MMS(String ppurioAccount, PpurioMessageDTO ppurioMessageDTO, MultipartFile multipartFile) {
-        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets());
+        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets(), ppurioMessageDTO.getSendTime());
 
         Files files;
         try {

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/MessageType.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/MessageType.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class MessageType {
      * @param message 전송될 메세지 내용
      * @param targets 전송할 대상의 정보와 추가 속성
      */
-    public MessageType(String ppurioAccount, String fromNumber, String message, List<Target> targets) {
+    public MessageType(String ppurioAccount, String fromNumber, String message, List<Target> targets, LocalDateTime sendTime) {
         params.put("account", ppurioAccount);
         params.put("messageType", "SMS");
         params.put("from", fromNumber);
@@ -36,6 +37,7 @@ public class MessageType {
         params.put("targetCount", targets.size());
         params.put("targets", targets);
         params.put("refKey", RandomStringUtils.random(32, true, true));
+        if(sendTime != null) params.put("sendTime", sendTime.toString());
     }
 
     /**

--- a/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/SMS.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/message/send/messagetype/SMS.java
@@ -15,14 +15,14 @@ import static com.precapstone.fiveguys_backend.api.message.send.PpurioErrorCode.
  */
 public class SMS extends MessageType {
     public SMS(String ppurioAccount, String fromNumber, String message, List targets) {
-        super(ppurioAccount, fromNumber, message, targets);
+        super(ppurioAccount, fromNumber, message, targets, null);
         // TODO: 문자 메세지 길이 파악하기
 
         params.put("messageType", "SMS");
     }
 
     public SMS(String ppurioAccount, PpurioMessageDTO ppurioMessageDTO) {
-        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets());
+        super(ppurioAccount, ppurioMessageDTO.getFromNumber(), ppurioMessageDTO.getContent(), ppurioMessageDTO.getTargets(), ppurioMessageDTO.getSendTime());
 
         // TODO: 문자 메세지 길이 파악하기
         if(ppurioMessageDTO.getContent().getBytes().length > 90) throw new ControlledException(CONTENT_IS_TOO_LONG);

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
@@ -28,7 +28,7 @@ public class MessageHistoryService {
     private final SendImageService sendImageService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public MessageHistory create(MessageHistoryDTO messageHistoryDTO) {
+    public MessageHistory create(MessageHistoryDTO messageHistoryDTO, String messageKey) {
         // TODO: 1. [예외처리] 전화번호 서식이 틀린 경우
 
         // TODO: 2. [예외처리] 본문 길이 틀린 경우
@@ -43,6 +43,7 @@ public class MessageHistoryService {
                 .subject(messageHistoryDTO.getSubject())
                 .content(messageHistoryDTO.getContent())
                 .user(user)
+                .messageKey(messageKey)
                 .build();
 
         // MMS인 경우에만 전달 받음
@@ -56,7 +57,7 @@ public class MessageHistoryService {
         return messageHistory;
     }
 
-    public MessageHistory createLink(MessageHistoryDTO messageHistoryDTO, String url) {
+    public MessageHistory createLink(MessageHistoryDTO messageHistoryDTO, String url, String messageKey) {
         // TODO: 1. [예외처리] 전화번호 서식이 틀린 경우
 
         // TODO: 2. [예외처리] 본문 길이 틀린 경우
@@ -71,6 +72,7 @@ public class MessageHistoryService {
                 .subject(messageHistoryDTO.getSubject())
                 .content(messageHistoryDTO.getContent())
                 .user(user)
+                .messageKey(messageKey)
                 .build();
 
         sendImageService.createLink(messageHistory, url);

--- a/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/messagehistory/MessageHistoryService.java
@@ -1,6 +1,7 @@
 package com.precapstone.fiveguys_backend.api.messagehistory;
 
 import com.precapstone.fiveguys_backend.api.auth.JwtTokenProvider;
+import com.precapstone.fiveguys_backend.entity.User;
 import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
 import com.precapstone.fiveguys_backend.entity.messagehistory.MessageType;
 import com.precapstone.fiveguys_backend.entity.SendImage;
@@ -17,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.precapstone.fiveguys_backend.exception.errorcode.MessageHistoryErrorCode.MESSAGE_HISTORY_NOT_FOUND;
+import static com.precapstone.fiveguys_backend.exception.errorcode.MessageHistoryErrorCode.MESSAGE_HISTORY_NOT_FOUND_BY_USER;
 import static com.precapstone.fiveguys_backend.exception.errorcode.UserErrorCode.USER_AUTHORIZATION_FAILED;
 import static com.precapstone.fiveguys_backend.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
 
@@ -143,6 +145,13 @@ public class MessageHistoryService {
         var messageHistory = read(messageHistoryId, accessToken);
 
         messageHistoryRepository.deleteByMessageHistoryId(messageHistoryId);
+        return messageHistory;
+    }
+
+    public List<MessageHistory> read(User user) {
+        var messageHistory = messageHistoryRepository.findByUser(user)
+                .orElseThrow(()-> new ControlledException(MESSAGE_HISTORY_NOT_FOUND_BY_USER));
+
         return messageHistory;
     }
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/Reservation.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/Reservation.java
@@ -1,4 +1,33 @@
 package com.precapstone.fiveguys_backend.api.reservation;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "reservation")
 public class Reservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reservationId;
+
+    @JsonBackReference
+    @JoinColumn(name = "message_history_id")
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private MessageHistory messageHistory;
+
+    @Column(nullable = false)
+    private LocalDateTime sendTime;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private ReservationState state = ReservationState.NOTYET;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/Reservation.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/Reservation.java
@@ -1,0 +1,4 @@
+package com.precapstone.fiveguys_backend.api.reservation;
+
+public class Reservation {
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationController.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationController.java
@@ -1,0 +1,25 @@
+package com.precapstone.fiveguys_backend.api.reservation;
+
+import com.precapstone.fiveguys_backend.common.CommonResponse;
+import com.precapstone.fiveguys_backend.common.auth.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/reservation/")
+@RequiredArgsConstructor
+public class ReservationController {
+    private final ReservationService reservationService;
+
+    // 전체 예약 조회
+    @GetMapping
+    public ResponseEntity read(@RequestHeader("Authorization") String authorization) {
+        var accessToken = authorization.replace(JwtFilter.TOKEN_PREFIX, "");
+
+        var reservations = reservationService.readAll(accessToken);
+
+        var response = CommonResponse.builder().code(200).message("전체 예약 조회 성공").data(reservations).build();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationRepository.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationRepository.java
@@ -1,0 +1,8 @@
+package com.precapstone.fiveguys_backend.api.reservation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationService.java
@@ -45,6 +45,10 @@ public class ReservationService {
                 .filter(Objects::nonNull)            // Reservation이 null이 아닌 경우만 포함
                 .toList();
 
+        for (var reservation : reservations)
+            if (reservation.getSendTime().isBefore(LocalDateTime.now()) || reservation.getState() == ReservationState.NOTYET)
+                changeType(reservation.getMessageHistory(), ReservationState.DONE);
+
         return reservations;
     }
 

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationService.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationService.java
@@ -1,0 +1,56 @@
+package com.precapstone.fiveguys_backend.api.reservation;
+
+import com.precapstone.fiveguys_backend.api.auth.JwtTokenProvider;
+import com.precapstone.fiveguys_backend.api.messagehistory.MessageHistoryService;
+import com.precapstone.fiveguys_backend.api.user.UserService;
+import com.precapstone.fiveguys_backend.entity.messagehistory.MessageHistory;
+import com.precapstone.fiveguys_backend.exception.ControlledException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import static com.precapstone.fiveguys_backend.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+    private final ReservationRepository reservationRepository;
+    private final UserService userService;
+    private final MessageHistoryService messageHistoryService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Reservation create(MessageHistory messageHistory, LocalDateTime sendTime) {
+        var reservation = Reservation.builder()
+                .messageHistory(messageHistory)
+                .sendTime(sendTime)
+                .build();
+
+        reservationRepository.save(reservation);
+        return reservation;
+    }
+
+    public List<Reservation> readAll(String accessToken) {
+        var userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+        var user = userService.findByUserId(userId)
+                .orElseThrow(() -> new ControlledException(USER_NOT_FOUND));
+
+        var messageHistories = messageHistoryService.read(user);
+
+        // 3. MessageHistory에서 Reservation 리스트 생성
+        List<Reservation> reservations = messageHistories.stream()
+                .map(MessageHistory::getReservation) // MessageHistory에서 Reservation 추출
+                .filter(Objects::nonNull)            // Reservation이 null이 아닌 경우만 포함
+                .toList();
+
+        return reservations;
+    }
+
+    public void changeType(MessageHistory messageHistory, ReservationState reservationState) {
+        var reservation = messageHistory.getReservation();
+        reservation.setState(reservationState);
+        reservationRepository.save(reservation);
+    }
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationState.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/api/reservation/ReservationState.java
@@ -1,0 +1,8 @@
+package com.precapstone.fiveguys_backend.api.reservation;
+
+public enum ReservationState {
+    DIRECT,
+    NOTYET,
+    DONE,
+    CANCEL
+}

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/User.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/User.java
@@ -35,5 +35,4 @@ public class User {
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonManagedReference
     private AmountUsed amountUsed;
-
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
@@ -51,4 +51,7 @@ public class MessageHistory {
     @JsonManagedReference
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Contact2> contact2s;
+
+    @Column(nullable = false, unique = true)
+    private String messageKey;
 }

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
@@ -33,7 +33,7 @@ public class MessageHistory {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "messageHistory")
     private SendImage sendImage;
 
-    @JsonManagedReference
+    @JsonBackReference
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "messageHistory")
     private Reservation reservation;
 

--- a/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/entity/messagehistory/MessageHistory.java
@@ -2,6 +2,7 @@ package com.precapstone.fiveguys_backend.entity.messagehistory;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.precapstone.fiveguys_backend.api.reservation.Reservation;
 import com.precapstone.fiveguys_backend.entity.SendImage;
 import com.precapstone.fiveguys_backend.entity.Contact2;
 import com.precapstone.fiveguys_backend.entity.User;
@@ -31,6 +32,10 @@ public class MessageHistory {
     @JsonManagedReference
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "messageHistory")
     private SendImage sendImage;
+
+    @JsonManagedReference
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "messageHistory")
+    private Reservation reservation;
 
     @Column(nullable = false)
     private String fromNumber;

--- a/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/MessageHistoryErrorCode.java
+++ b/src/main/java/com/precapstone/fiveguys_backend/exception/errorcode/MessageHistoryErrorCode.java
@@ -4,4 +4,5 @@ import com.precapstone.fiveguys_backend.exception.ErrorMessage;
 
 public interface MessageHistoryErrorCode {
     ErrorMessage MESSAGE_HISTORY_NOT_FOUND = new ErrorMessage(-6001, "조회된 메세지 기록이 없습니다.");
+    ErrorMessage MESSAGE_HISTORY_NOT_FOUND_BY_USER = new ErrorMessage(-6001, "유저로부터 조회된 메세지 기록이 없습니다.");
 }


### PR DESCRIPTION
# :: 작업 주제
*FG-49* : 이미지 예약 전송 기능 추가

# :: 구현사항 설명
1. reservation 엔티티 추가
2. 뿌리오 예약 메세지 취소 API 연동
3. 메세지 조회 시, 전송된 메세지는 예약 타입이 NOT_YET에서 DONE으로 변경됨

# :: 보완할점
<보완사항, 주의사항>
- [ ] 실제 전송 후 기록을 보기위해 메인 서버에서 테스트 필요

<추가로 알아야할 사항>
